### PR TITLE
bump to major version and adjust description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Multi-signature
+# TzSafe
+Tzsafe is a multisig wallet aiming at providing better assurance of security and management of ownership than a traditional single-signed wallet.
+
 Multi-signature (also multisig) wallet allows to share the ownership of an account by a smart contract. Each owner can create a proposal to propose transferring Tez or executing other contracts. Signer provides approval stored on-chain by performing Tezos transaction. Once gathering the minimal approvals, the multisig will perform the proposal.
 
 # Requirements

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "test": "ligo run test test/test.mligo --project-root ."
   },
   "dependencies": {
-    "ligo-breathalyzer": "1.2.1"
+    "ligo-breathalyzer": "1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "TzSafe Contract",
+  "name": "TzSafe",
   "version": "0.2.0",
   "author": "Marigold <contact@marigold.dev>",
   "description": "TzSafe is a multisig wallet aiming at providing better assurance of security and management of ownership than a traditional single-signed wallet",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "multi-signature",
-  "version": "0.0.13",
+  "name": "TzSafe Contract",
+  "version": "0.2.0",
   "author": "Marigold <contact@marigold.dev>",
-  "description": "Multi-signature wallet",
+  "description": "TzSafe is a multisig wallet aiming at providing better assurance of security and management of ownership than a traditional single-signed wallet",
   "scripts": {
     "test": "ligo run test test/test.mligo --project-root ."
   },
   "dependencies": {
-    "ligo-breathalyzer": "^1.2.1"
+    "ligo-breathalyzer": "1.2.1"
   }
 }

--- a/script/gen_metadata.sh
+++ b/script/gen_metadata.sh
@@ -2,8 +2,8 @@
 
 echo '
 {
-    "name": "multisig",
-    "description": "Marigold Multisig Contract",
+    "name": "TzSafe",
+    "description": "TzSafe is a multisig wallet aiming at providing better assurance of security and management of ownership than a traditional single-signed wallet",
     "version": "'${VERSION}'",
     "license": {
         "name": "MIT"
@@ -11,10 +11,10 @@ echo '
     "authors": [
         "Marigold <contract@marigold.dev>"
     ],
-    "homepage": "https://marigold.dev",
+    "homepage": "https://www.marigold.dev/tzsafe",
     "source": {
         "tools": "cameligo",
-        "location": "https://github.com/marigold-dev/multisig/"
+        "location": "https://github.com/marigold-dev/tzsafe/"
     },
     "interfaces": [
         "TZIP-016"


### PR DESCRIPTION
-  bump 0.0.13 to 0.2.0
   - these two version haven't been supported by UI yet. 
   - the major change is support ticket
- rename multisig to tzsafe